### PR TITLE
Update controller.py: correctly re-raise exceptions

### DIFF
--- a/sp110e/controller.py
+++ b/sp110e/controller.py
@@ -208,7 +208,7 @@ class Controller:
                     await self._driver.connect(self._mac, timeout=self._timeout)
             except Exception:
                 if i == self._retries:
-                    raise Exception
+                    raise
 
     async def _connect_and_write_parameters(self, parameters: dict, force: bool = False) -> None:
         """Write parameter to device with auto connect."""


### PR DESCRIPTION
In case of retries exceeded, re-raise exception instead of raising `Exception`

---

Current stacktrace: 
```
File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/controller.py:29, in Controller.connect(self)
     27 async def connect(self):
     28     """Establish BLE connection to device."""
---> 29     await self._connect_with_retries()

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/controller.py:211, in Controller._connect_with_retries(self)
    209 except Exception:
    210     if i == self._retries:
--> 211         raise Exception
```

with proposed changes:
```

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/controller_sync.py:28, in ControllerSync.connect(self)
     25 @sync
     26 async def connect(self):
     27     """Establish BLE connection to device."""
---> 28     await super().connect()

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/controller.py:29, in Controller.connect(self)
     27 async def connect(self):
     28     """Establish BLE connection to device."""
---> 29     await self._connect_with_retries()

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/controller.py:208, in Controller._connect_with_retries(self)
    206 try:
    207     if not self._driver.is_connected():
--> 208         await self._driver.connect(self._mac, timeout=self._timeout)
    209 except Exception:
    210     if i == self._retries:

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/sp110e/driver.py:47, in Driver.connect(self, mac_address, timeout, auto_read)
     45 self._client = BleakClient(device)
     46 await self._client.connect()
---> 47 await self._client.start_notify(self.CHARACTERISTIC, self._callback_handler)
     48 if auto_read:
     49     return await self.read_parameters()

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/bleak/__init__.py:844, in BleakClient.start_notify(self, char_specifier, callback, **kwargs)
    841 else:
    842     wrapped_callback = functools.partial(callback, characteristic)
--> 844 await self._backend.start_notify(characteristic, wrapped_callback, **kwargs)

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/bleak/backends/bluezdbus/client.py:959, in BleakClientBlueZDBus.start_notify(self, characteristic, callback, **kwargs)
    949 assert self._bus is not None
    951 reply = await self._bus.call(
    952     Message(
    953         destination=defs.BLUEZ_SERVICE,
   (...)
    957     )
    958 )
--> 959 assert_reply(reply)

File ~/dev/led_lights/.venv/lib/python3.13/site-packages/bleak/backends/bluezdbus/utils.py:20, in assert_reply(reply)
     13 """Checks that a D-Bus message is a valid reply.
     14 
     15 Raises:
     16     BleakDBusError: if the message type is ``MessageType.ERROR``
     17     AssertionError: if the message type is not ``MessageType.METHOD_RETURN``
     18 """
     19 if reply.message_type == MessageType.ERROR:
---> 20     raise BleakDBusError(reply.error_name, reply.body)
     21 assert reply.message_type == MessageType.METHOD_RETURN

BleakDBusError: [org.bluez.Error.Failed] Operation failed with ATT error: 0x0e (Unlikely Error)
```